### PR TITLE
Add slide in from left and right, make treatbot timeout configurable

### DIFF
--- a/obs.py
+++ b/obs.py
@@ -103,6 +103,23 @@ async def yay(value):
             yay_active = False
 
 
+async def follow(follower):
+    source = "NewFollowScene"
+    text_box = "Follower"
+    scene = "Common"
+    step = 40
+
+    # Turn the source off, just in case it was left on.
+    obs_client.call(requests.SetSceneItemRender(False, source, scene_name=scene))
+
+    # Set the follower text
+    obs_client.call(requests.SetTextFreetype2Properties(text_box, text=follower))
+
+    await slide_in_from_right(source, scene, step, -1)
+
+    # Turn the source back off
+    obs_client.call(requests.SetSceneItemRender(False, source, scene_name=scene))
+
 
 async def slide_in_from_right(source: str, scene: str, step: int, height: int):
     """Slides a OBS Source in from the right side of the display
@@ -256,6 +273,7 @@ if __name__ == "__main__":
     feeds = {
         "dispense-treat-toggle": treatbot_cam,
         "yay-toggle": yay,
+        # "follow": follow,
     }
 
     STOP = asyncio.Event()

--- a/obs.py
+++ b/obs.py
@@ -2,6 +2,7 @@ import asyncio
 import signal
 from json import loads
 from secrets import Secrets as secrets
+from secrets import Settings
 from secrets import Sources
 from time import sleep
 
@@ -63,7 +64,7 @@ async def treatbot_cam(value):
 
     if enabled:
         treatbot_active = True
-        await asyncio.sleep(17)
+        await asyncio.sleep(Settings.treatbot_timeout)
         if treatbot_active:
             print(
                 "Hrm.... the treatbot didn't disable the OBS display. Disabling it..."

--- a/secrets.py.template
+++ b/secrets.py.template
@@ -16,3 +16,8 @@ class Sources:
     treatbot_cam_scene: str = ""
     yay_source: str = ""
     yay_scene: str = ""
+
+
+@dataclass
+class Settings:
+    treatbot_timeout: int = 17


### PR DESCRIPTION
Add functions to slide a scene in from the left or right, a new followers scene as a sample, but is not active at the moment.
make treatbot timeout configurable.